### PR TITLE
feat: enable npx -y execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";


### PR DESCRIPTION
The lack of shebang prevented `npx -y {package name}` from working. Note that it also helps on Windows.

To see a larger context of this change, npx -y is now a goto recipe to install MCP servers, so it's nice to have an ability to run `n8n-mcp-server ` using MCP. For example https://mcp.pipedream.com/app/gitlab offers the follwing instruction. Note that the console MCP that Claude used is automagically installed by npx.

![image](https://github.com/user-attachments/assets/2ed8ed75-9a43-4221-a78d-eca34ee3b48e)


